### PR TITLE
Fixed tclmpi::wait and tclmpi::waitall

### DIFF
--- a/_tclmpi.c
+++ b/_tclmpi.c
@@ -2757,8 +2757,8 @@ int TclMPI_Wait(ClientData nodata, Tcl_Interp *interp, int objc, Tcl_Obj *const 
     /* waiting on an illegal request returns immediately */
     if (req == NULL) return TCL_OK;
 
-    if (objc > 4)
-        statvar = Tcl_GetString(objv[4]);
+    if (objc > 2)
+        statvar = Tcl_GetString(objv[2]);
     else
         statvar = NULL;
 

--- a/tclmpi.tcl.in
+++ b/tclmpi.tcl.in
@@ -46,10 +46,29 @@ namespace eval tclmpi {
 
     variable undefined  tclmpi::undefined  ;# constant to indicate an undefined number
 
-    proc waitall {requests {status {}}} {
+    proc waitall {requests {statvar {}}} {
         set retval {}
-        foreach req {$requests} {
-            lappend retval [wait $req]
+        if {$statvar eq ""} {
+            foreach req $requests {
+                lappend retval [wait $req]
+            }
+        } else {
+            upvar $statvar status
+            set status(MPI_SOURCE) {}
+            set status(MPI_TAG) {}
+            set status(MPI_ERROR) {}
+            set status(COUNT_CHAR) {}
+            set status(COUNT_INT) {}
+            set status(COUNT_DOUBLE) {}
+            foreach req $requests {
+                lappend retval [wait $req temp]
+                lappend status(MPI_SOURCE) $temp(MPI_SOURCE)
+                lappend status(MPI_TAG) $temp(MPI_TAG)       
+                lappend status(MPI_ERROR) $temp(MPI_ERROR)   
+                lappend status(COUNT_CHAR) $temp(COUNT_CHAR)  
+                lappend status(COUNT_INT) $temp(COUNT_INT)   
+                lappend status(COUNT_DOUBLE) $temp(COUNT_DOUBLE)
+            }
         }
         return $retval
     }


### PR DESCRIPTION
tclmpi::waitall did not work at all, and tclmpi::wait was missing the status array feature. 
This PR fixes both. Here's a simple script to test it out:

```
package require tclmpi
::tclmpi::init
set comm tclmpi::comm_world
if {[::tclmpi::comm_rank $comm] == 0} {
    ::tclmpi::send "Hello World" tclmpi::auto 1 42 tclmpi::comm_world
    ::tclmpi::send "Fizz Buzz" tclmpi::auto 1 42 tclmpi::comm_world
    ::tclmpi::send "Hello World" tclmpi::auto 2 42 tclmpi::comm_world
    ::tclmpi::send "Fizz Buzz" tclmpi::auto 2 42 tclmpi::comm_world
} else {
    set req1 [::tclmpi::irecv tclmpi::auto 0 42 $comm]
    set req2 [::tclmpi::irecv tclmpi::auto 0 42 $comm]
    puts [::tclmpi::waitall [list $req1 $req2] status]
    parray status
}
::tclmpi::finalize
```